### PR TITLE
Update the project start scripts and procedures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea/
 *.pyc
 todo.txt
-config.json
 live_config.json

--- a/README.md
+++ b/README.md
@@ -2,12 +2,18 @@
 A chat bot that keeps you connected to important political decisions
 
 
+## Execution
+
+1. Update the project configuration, `config.json`
+2. Check and install the requirements by running reqs.sh
+3. Set the environment vars and execute by running run.sh
+
 ## Development
 
-Setup:
+System requirements:
 
-1. Acquire appropriate `config.json` file
-2. `source setup.sh`
+* Unix-like environment
+* Python 3
 
 How to run static analysis: `pylint -E $(find . -type f -name "*.py")`
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,20 @@
+{
+    "google": {
+        "api_key": null
+    }, 
+    "api_host": {
+        "port": 8000, 
+        "name": "localhost"
+    }, 
+    "twilio": {
+        "account_sid": null, 
+        "auth_token": null
+    }, 
+    "dynamodb": {
+        "access_key": null, 
+        "secret_key": null
+    }, 
+    "sunlight": {
+        "api_key": null
+    }
+}

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,5 @@
+# These are required for the app to execute
+export FLASK_APP=${FLASK_APP-"politi_hack.flask"}
+export POLITI_HACK_CONFIG_PATH=${POLITI_HACK_CONFIG_PATH-$(readlink -m ./config.json)}
+export PYTHONPATH=${PYTHONPATH-$(pwd)}
+export PYTHONPATH=$PYTHONPATH:$(pwd)

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,5 @@
 # These are required for the app to execute
 export FLASK_APP=${FLASK_APP-"politi_hack.flask"}
-export POLITI_HACK_CONFIG_PATH=${POLITI_HACK_CONFIG_PATH-$(readlink -m ./config.json)}
+export POLITI_HACK_CONFIG_PATH=${POLITI_HACK_CONFIG_PATH-$(pwd)/config.json}
 export PYTHONPATH=${PYTHONPATH-$(pwd)}
 export PYTHONPATH=$PYTHONPATH:$(pwd)

--- a/reqs.sh
+++ b/reqs.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+source ./env.sh
+if [ ! -e $POLITI_HACK_CONFIG_PATH ]; then
+    echo "Error, PolitiHack config file not found:"
+    echo "POLITI_HACK_CONFIG_PATH=$POLITI_HACK_CONFIG_PATH"
+    exit 1
+fi
+pip3 install -r requirements.txt --upgrade
+if [ $? -eq 0 ]; then
+    echo "Pre-requisites to run PolitiHack are met."
+    echo "To run, use ./run.sh"
+fi

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+source ./env.sh
+python3 ./start.py

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# Set up enviornment variables
-export FLASK_APP='politi_hack.flask'
-export POLITI_HACK_CONFIG_PATH='./config.json'
-export PYTHONPATH=${PYTHONPATH}:./
-
-# Install pip requirements
-sudo pip3 install -r requirements.txt --upgrade

--- a/shared/config.py
+++ b/shared/config.py
@@ -5,38 +5,5 @@ import os
 MAX_TWILIO_MSG_SIZE  = 1600
 SERVICE_PHONE_NUMBER = "+18554164150"
 
-# Environment variables
-POLITI_HACK_CONFIG_PATH = 'POLITI_HACK_CONFIG_PATH'
-
-# This is just a template, the actual config is loaded from disk on startup,
-# then overwrites the below data.
-# Most config changes should occur in the json config file, NOT here.
-store = {
-    "api_host": {
-        "name": "localhost",
-        "port": 8000,
-    },
-    "dynamodb": {
-        "access_key": None,
-        "secret_key": None,
-    },
-    "google": {
-        "api_key": None,
-    },
-    "sunlight": {
-        "api_key": None
-    },
-    "twilio": {
-        "account_sid": None,
-        "auth_token": None,
-    },
-}
-
-
-def load_from_disk(filepath):
-    global store
-    with open(filepath, "r") as f:
-        store = json.loads(f.read())
-
-# Load the config into store
-load_from_disk(os.path.abspath(os.environ[POLITI_HACK_CONFIG_PATH]))
+with open(os.path.abspath(os.environ['POLITI_HACK_CONFIG_PATH']), "r") as f:
+    store = json.loads(f.read())

--- a/start.py
+++ b/start.py
@@ -6,7 +6,7 @@ import shared.config as config
 log = logging.getLogger(__name__)
 
 # Flask commands to run
-FLASK_COMMAND = "python3.4 -m flask run --host={host_name} --port={port}".format(
+FLASK_COMMAND = "python3 -m flask run --host={host_name} --port={port}".format(
     host_name=config.store['api_host']['name'],
     port=config.store['api_host']['port'],
 )


### PR DESCRIPTION
This is squash of commits from my local tree that cleans up the setup and start procedures for PolitiHack.

Specific changes (as seen in git log):
* Seperate environment setting and setup -> env.sh and reqs.sh
* Sensible defaults for env vars in env.sh if they are not set
* User able to overwrite environment variables by setting them
* Provide config.json as a replaceable template
* Update README for new env.sh, run.sh, and reqs.sh
* reqs.sh should check if config file exists
* run.sh created to wrap env set and executing project
* Don't lock Flask on subversion of Python 3
* Don't assume sudo is necessary for prereq installs